### PR TITLE
addition of clang-format

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,32 +1,54 @@
-name: Publish Docker image
+name: Create and publish a Docker image
 
 on:
   push:
     branches:
       - main
-  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build-and-push-image:
+    runs-on: ubuntu-22.04
+
     permissions:
-      packages: write
       contents: read
+      packages: write
+      attestations: write
+      id-token: write
 
     steps:
-      - name: Checkout repo
+      - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Log in to GHCR
+      - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
         with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}/custom-ros-builder:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
 

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,32 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ghcr.io/${{ github.repository }}/custom-ros-builder:latest
+

--- a/sim_ws/Dockerfile
+++ b/sim_ws/Dockerfile
@@ -36,7 +36,8 @@ RUN apt-get update --fix-missing && \
                        ros-humble-nav2-bringup \
                        ros-humble-xacro \
                        ros-humble-udp-msgs \
-                       x11-apps
+                       x11-apps \
+                       clang-format
 
 RUN pip3 install transforms3d gym
 

--- a/sim_ws/src/scripts/entrypoint.sh
+++ b/sim_ws/src/scripts/entrypoint.sh
@@ -7,6 +7,8 @@ if ! python3 -c "import f110_gym" &> /dev/null; then
     pip3 install -e /sim_ws/src/f1tenth_gym
 fi
 
+chmod +x /sim_ws/src/arcus/scripts/lint-apply.sh
+
 # Source ROS setup
 source /opt/ros/humble/setup.bash
 source /sim_ws/install/setup.bash


### PR DESCRIPTION
- authorizing lint-apply script automatically in the docker
- adding clang-format in docker dependencies
- adding a pipeline automatically publishing our latest docker image on ghcr.io/robotique-udes/arcus-simulation:latest (this will allow having a CI/CD pipeline in the main arcus repo using our docker image to easily and quickly test build the project)